### PR TITLE
Generalize the crawl shell wrapper script.

### DIFF
--- a/src/webserver/crawl.sh
+++ b/src/webserver/crawl.sh
@@ -1,3 +1,7 @@
-cd /home/ubuntu/Interval-Scheduling-Algorithm-with-Applied-Constraints/src/webserver
-/usr/bin/python crawl.py
+#!/bin/sh
 
+cd $HOME/Interval-Scheduling-Algorithm-with-Applied-Constraints/src/webserver
+
+# If you want to use a different python interpreter, set your
+# $PATH to something else.
+python crawl.py


### PR DESCRIPTION
Removed some hard-coded paths, added shebang line.  This should allow users to make the script executable and run it normally.

e.g.

`./src/webserver/crawl.sh`

Since it is an executable script and not a library, consider dropping the `.sh` extension.
