### PR TITLE
Broken query on MySQL > 5.7.x

### DIFF
--- a/src/webserver/database/dbHandler.py
+++ b/src/webserver/database/dbHandler.py
@@ -186,10 +186,9 @@ def getAvailableCourses(semester):
         for subrow in subjectquery:
             coursesdict[subrow.subject] = []
 
-            coursequery = Sectiondb.select().\
+            coursequery = Sectiondb.select(Sectiondb.code).\
                             where(Sectiondb.subject == subrow.subject,
                                   Sectiondb.semester == sem).\
-                            group_by(Sectiondb.code).\
                             distinct().naive()
             if coursequery.exists():
                 for row in coursequery:


### PR DESCRIPTION
This PR fixes a query that was permitted by MySQL < 5.7.5 but is considered invalid by the SQL92 standard.  More information here:  https://dev.mysql.com/doc/refman/5.7/en/group-by-handling.html.
